### PR TITLE
Make Thumbnails Horizontally Scrollable

### DIFF
--- a/style.css
+++ b/style.css
@@ -286,12 +286,15 @@ header .menu {
     position: absolute;
     bottom: 50px;
     left: 50%;
-    width: max-content;
+    width: 50%;
     z-index: 100;
     display: flex;
     gap: 20px;
     cursor: grab;
     transition: .4s ease;
+    box-sizing: border-box; /* Includes padding/border in size */
+    padding: 100px 25px; /* 100px padding to the top and bottom, 25px to the left and right */
+    overflow-x: auto; /* Enables horizontal scroll */
 }
 
 .thumbnail .item {
@@ -299,7 +302,6 @@ header .menu {
     height: 220px;
     flex-shrink: 0;
     position: relative;
-    bottom: 70px;
     transition: 0.2s ease-in-out;
 }
 
@@ -333,7 +335,6 @@ header .menu {
 
 .thumbnail .item .content .description {
     font-weight: 300;
-    text-shadow
 }
 
 /* Arrows */


### PR DESCRIPTION
- Implemented horizontal scrolling for the thumbnails section.
- Modified the width to 50% to improve layout and fit within the screen.
- Enabled overflow-x: auto to allow scrolling when thumbnails exceed the container width.
- Adjusted padding and box-sizing for proper layout and spacing.
- Removed unnecessary bottom positioning for improved alignment.
- Removed unused text-shadow property for cleaner code.